### PR TITLE
Add theme toggle assets and toast notifications

### DIFF
--- a/mvp-tickets/static/ui.css
+++ b/mvp-tickets/static/ui.css
@@ -1,0 +1,52 @@
+:root{
+  --bg:255 255 255;--fg:15 23 42;--muted:100 116 139;
+  --brand:59 130 246;--ok:5 150 105;--warn:245 158 11;--err:239 68 68;
+  --radius:1rem
+}
+.dark{
+  --bg:2 6 23;--fg:226 232 240;--muted:148 163 184;--brand:96 165 250
+}
+html{font-size:clamp(14px,1.05vw,16px)}
+body{background-color:rgb(var(--bg));color:rgb(var(--fg));}
+
+.card{border:1px solid rgba(148,163,184,.25);border-radius:var(--radius);
+  background:rgba(255,255,255,.75);backdrop-filter:saturate(140%) blur(6px);
+  box-shadow:0 1px 2px rgba(0,0,0,.04)}
+.dark .card{background:rgba(2,6,23,.6)}
+
+.btn{display:inline-flex;gap:.5rem;align-items:center;font-weight:600;
+  padding:.5rem 1rem;border:1px solid rgba(148,163,184,.35);
+  border-radius:calc(var(--radius) - .25rem);transition:transform .06s ease}
+.btn:active{transform:translateY(1px)}
+.btn-primary{border-color:transparent;background:rgb(var(--brand));color:#fff}
+.btn-ghost{border-color:transparent;background:transparent}
+
+.input{width:100%;border:1px solid rgba(148,163,184,.45);background:#fff;
+  border-radius:calc(var(--radius) - .25rem);padding:.5rem .75rem}
+.input:focus{outline:2px solid rgba(59,130,246,.25);outline-offset:2px}
+.dark .input{background:rgba(255,255,255,.03)}
+
+.table{width:100%;border-collapse:separate;border-spacing:0}
+.table tr:nth-child(odd){background:rgba(148,163,184,.08)}
+.dark .table tr:nth-child(odd){background:rgba(255,255,255,.04)}
+.table tr:hover{background:rgba(148,163,184,.14)}
+.th{font-weight:600;color:rgb(var(--muted));text-align:left;padding:.75rem}
+.td{padding:.75rem;border-top:1px solid rgba(148,163,184,.25)}
+
+.chip{display:inline-flex;gap:.375rem;align-items:center;font-size:.75rem;
+  padding:.25rem .5rem;border-radius:999px}
+.chip-ok{background:rgba(5,150,105,.15);color:rgb(5,150,105)}
+.chip-warn{background:rgba(245,158,11,.18);color:rgb(245,158,11)}
+.chip-err{background:rgba(239,68,68,.15);color:rgb(239,68,68)}
+
+header.site{
+  position:sticky;top:0;z-index:50;backdrop-filter:blur(8px);
+  border-bottom:1px solid rgba(255,255,255,.2);
+  background:rgba(255,255,255,.7)
+}
+.dark header.site{background:rgba(2,6,23,.6)}
+
+.toast-wrap{position:fixed;top:1rem;right:1rem;display:grid;gap:.5rem}
+.toast{padding:.75rem 1rem}.toast-info{background:rgba(59,130,246,.15)}
+.toast-ok{background:rgba(5,150,105,.15)}.toast-warn{background:rgba(245,158,11,.18)}
+.toast-err{background:rgba(239,68,68,.15)}

--- a/mvp-tickets/static/ui.js
+++ b/mvp-tickets/static/ui.js
@@ -1,0 +1,26 @@
+// Dark mode toggle
+(function(){
+  const root=document.documentElement;
+  const saved=localStorage.getItem("theme");
+  if(saved){ if(saved==="dark") root.classList.add("dark"); }
+  else if(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches){
+    root.classList.add("dark");
+  }
+  document.addEventListener("click",e=>{
+    const t=e.target.closest("#theme-toggle"); if(!t) return;
+    root.classList.toggle("dark");
+    localStorage.setItem("theme", root.classList.contains("dark")?"dark":"light");
+  });
+})();
+
+// HTMX indicator (if HTMX exists)
+(function(){
+  const ind=document.createElement("div");
+  ind.id="hx-indicator";
+  ind.style.cssText="position:fixed;bottom:1rem;right:1rem;padding:.5rem .75rem;border-radius:.75rem;border:1px solid rgba(148,163,184,.35);background:rgba(255,255,255,.9)";
+  ind.textContent="Cargando…"; ind.hidden=true; document.body.appendChild(ind);
+  document.body.setAttribute("hx-indicator","#hx-indicator");
+  document.addEventListener("htmx:beforeRequest",()=>{ind.hidden=false;});
+  document.addEventListener("htmx:afterOnLoad",()=>{ind.hidden=true;});
+  document.addEventListener("htmx:responseError",()=>{ind.hidden=true;});
+})();

--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -78,10 +78,22 @@
       color: #1d4ed8;
     }
   </style>
+  <link rel="stylesheet" href="{% static 'ui.css' %}">
   {% block head_extra %}{% endblock %}
 </head>
 <body class="bg-gray-50 text-gray-900">
-  <header class="bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
+  {% if messages %}
+  <div class="toast-wrap" role="status" aria-live="polite">
+    {% for message in messages %}
+      {% with lvl=message.tags %}
+        <div class="card toast {% if 'success' in lvl %}toast-ok{% elif 'warning' in lvl %}toast-warn{% elif 'error' in lvl %}toast-err{% else %}toast-info{% endif %}">
+          {{ message }}
+        </div>
+      {% endwith %}
+    {% endfor %}
+  </div>
+  {% endif %}
+  <header class="site bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
     <div class="w-full pl-4 pr-6 py-3 flex justify-between items-center">
       <div class="flex items-center gap-8">
         <a href="{% url 'dashboard' %}" class="font-bold text-2xl flex items-center gap-1 tracking-tight">
@@ -109,6 +121,7 @@
       </div>
 
       <div class="flex items-center gap-6 text-sm">
+        <button id="theme-toggle" class="btn btn-ghost" type="button" aria-label="Cambiar tema">Tema</button>
         {% if request.user.is_authenticated %}
           {% if request.user|has_group:"ADMINISTRADOR" or request.user.is_superuser %}
             <details class="nav-admin relative z-40">
@@ -152,24 +165,11 @@
 
 
   <main class="w-full px-6 py-6">
-    {# --- Mensajes flash --- #}
-    {% if messages %}
-      <div class="space-y-2 mb-4">
-        {% for m in messages %}
-          <div class="px-3 py-2 rounded text-sm
-              {% if m.tags == 'error' %}bg-red-50 text-red-700 border border-red-200
-              {% elif m.tags == 'warning' %}bg-yellow-50 text-yellow-700 border border-yellow-200
-              {% else %}bg-green-50 text-green-700 border border-green-200{% endif %}">
-            {{ m }}
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
-
     {% block content %}{% endblock %}
   </main>
 
   {% block body_extra %}{% endblock %}
+  <script src="{% static 'ui.js' %}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add shared ui.css and ui.js assets for theming, dark mode, and HTMX indicator
- enhance base layout with toast message wrapper, theme toggle button, and new asset includes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9bb1ca28832191c40c84871a4c29