### PR TITLE
Add opt-in dashboard stat card presentation

### DIFF
--- a/mvp-tickets/static/ui.css
+++ b/mvp-tickets/static/ui.css
@@ -69,3 +69,104 @@ header.site{
   header.site,.toast-wrap,nav,.btn{display:none!important}
   a[href]::after{content:" (" attr(href) ")";font-size:.75em}
 }
+/* Stats / Cards (opt-in) */
+.stat-grid{
+  display:grid;
+  gap:1.25rem;
+  grid-template-columns:repeat(auto-fit,minmax(16rem,1fr));
+  align-items:stretch;
+}
+
+.stat-grid>.stat-card{height:100%}
+
+.stat-card{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+  padding:1.25rem;
+  border:1px solid rgba(148,163,184,.25);
+  border-radius:var(--radius);
+  background:rgba(255,255,255,.72);
+  box-shadow:0 20px 45px -25px rgba(15,23,42,.35);
+  transition:transform .25s ease,box-shadow .25s ease;
+}
+
+.stat-card:hover{
+  transform:translateY(-2px);
+  box-shadow:0 24px 55px -25px rgba(15,23,42,.45);
+}
+
+.dark .stat-card{background:rgba(15,23,42,.55);border-color:rgba(148,163,184,.35);box-shadow:0 20px 45px -30px rgba(15,23,42,.9)}
+
+.stat-card .stat-shell{display:flex;flex-direction:column;gap:1rem;min-height:100%}
+
+.stat-card .stat-head{display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem}
+
+.stat-card .k{font-size:.75rem;font-weight:700;letter-spacing:.18em;text-transform:uppercase;color:rgb(var(--muted));}
+
+.stat-card .stat-badge{
+  display:inline-flex;
+  align-items:center;
+  gap:.35rem;
+  padding:.25rem .65rem;
+  font-size:.75rem;
+  font-weight:600;
+  line-height:1;
+  border-radius:999px;
+  background:rgba(148,163,184,.18);
+  color:rgb(var(--fg));
+  white-space:nowrap;
+}
+
+.stat-card .stat-badge-ok{background:rgba(5,150,105,.18);color:rgb(5,150,105)}
+.stat-card .stat-badge-warn{background:rgba(245,158,11,.18);color:rgb(245,158,11)}
+.stat-card .stat-badge-err{background:rgba(239,68,68,.18);color:rgb(239,68,68)}
+.stat-card .stat-badge-info{background:rgba(59,130,246,.18);color:rgb(59,130,246)}
+.stat-card .stat-badge-neutral{background:rgba(148,163,184,.18);color:rgb(100,116,139)}
+
+.stat-card .stat-value-row{display:flex;flex-wrap:wrap;align-items:baseline;gap:.6rem}
+
+.stat-card .v{font-size:clamp(1.85rem,2vw + 1rem,2.75rem);font-weight:700;line-height:1.05;letter-spacing:-.01em}
+
+.stat-card .delta{display:inline-flex;align-items:center;gap:.35rem;font-weight:600;font-size:.9rem;white-space:nowrap}
+.stat-card .delta-positive{color:rgb(5,150,105)}
+.stat-card .delta-negative{color:rgb(239,68,68)}
+.stat-card .delta-neutral{color:rgb(var(--muted))}
+
+.stat-card .stat-progress{display:flex;flex-direction:column;gap:.4rem}
+
+.stat-card .stat-progress-track{
+  position:relative;
+  width:100%;
+  height:.55rem;
+  border-radius:999px;
+  background:linear-gradient(90deg,rgba(148,163,184,.18),rgba(148,163,184,.12));
+  overflow:hidden;
+}
+
+.stat-card .stat-progress-bar{
+  position:absolute;
+  inset:0 auto 0 0;
+  width:0;
+  max-width:100%;
+  background:linear-gradient(135deg,rgba(59,130,246,.9),rgba(96,165,250,.9));
+  border-radius:inherit;
+  transition:width .6s cubic-bezier(.4,0,.2,1);
+}
+
+.dark .stat-card .stat-progress-track{background:linear-gradient(90deg,rgba(148,163,184,.25),rgba(148,163,184,.18))}
+.dark .stat-card .stat-progress-bar{background:linear-gradient(135deg,rgba(59,130,246,.75),rgba(37,99,235,.85))}
+
+.stat-card .stat-progress-value{font-size:.8rem;font-weight:600;color:rgb(var(--muted))}
+
+.stat-card .stat-foot{display:flex;flex-direction:column;gap:.75rem}
+
+.stat-card .stat-sparkline{width:100%;height:3rem;display:block}
+.stat-card .stat-sparkline path{fill:rgba(59,130,246,.18)}
+.stat-card .stat-sparkline polyline{fill:none;stroke:rgba(59,130,246,.85);stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round}
+
+.dark .stat-card .stat-sparkline path{fill:rgba(59,130,246,.12)}
+.dark .stat-card .stat-sparkline polyline{stroke:rgba(96,165,250,.85)}
+
+.stat-card .stat-extra{margin-top:1rem;color:inherit;font-size:.85rem;opacity:.85}

--- a/mvp-tickets/static/ui.js
+++ b/mvp-tickets/static/ui.js
@@ -150,3 +150,336 @@
   document.addEventListener('htmx:afterRequest', handleHtmxRelease);
   document.addEventListener('htmx:responseError', handleHtmxRelease);
 })();
+// Stats / Cards (opt-in, no template rewrites obligatorios)
+(function(){
+  const SELECTOR = '.stat-card';
+  const RELEVANT_KEYS = new Set(['key','value','delta','status','progress','series']);
+  const STATUS_CLASS_MAP = {
+    ok:'stat-badge-ok',
+    good:'stat-badge-ok',
+    ready:'stat-badge-ok',
+    success:'stat-badge-ok',
+    positive:'stat-badge-ok',
+    warn:'stat-badge-warn',
+    warning:'stat-badge-warn',
+    caution:'stat-badge-warn',
+    pending:'stat-badge-warn',
+    hold:'stat-badge-warn',
+    err:'stat-badge-err',
+    error:'stat-badge-err',
+    danger:'stat-badge-err',
+    fail:'stat-badge-err',
+    down:'stat-badge-err',
+    info:'stat-badge-info',
+    notice:'stat-badge-info',
+    neutral:'stat-badge-neutral',
+    default:'stat-badge-neutral'
+  };
+  const BADGE_VARIANTS = ['stat-badge-ok','stat-badge-warn','stat-badge-err','stat-badge-info','stat-badge-neutral'];
+  const DELTA_VARIANTS = ['delta-positive','delta-negative','delta-neutral'];
+  const cardStore = new WeakMap();
+
+  const hasRelevantData = (card) => {
+    const dataset = card.dataset || {};
+    for(const key of Object.keys(dataset)){
+      if(RELEVANT_KEYS.has(key)) return true;
+    }
+    return false;
+  };
+
+  const takeExistingChildren = (card) => {
+    const existing = [];
+    card.childNodes.forEach(node => {
+      if(node.nodeType === Node.TEXT_NODE && !node.textContent.trim()){
+        return;
+      }
+      existing.push(node);
+    });
+    existing.forEach(node => card.removeChild(node));
+    return existing;
+  };
+
+  const buildCard = (card) => {
+    const preserved = takeExistingChildren(card);
+    const shell = document.createElement('div');
+    shell.className = 'stat-shell';
+
+    const head = document.createElement('div');
+    head.className = 'stat-head';
+
+    const keyEl = document.createElement('span');
+    keyEl.className = 'k';
+    head.appendChild(keyEl);
+
+    const badge = document.createElement('span');
+    badge.className = 'stat-badge';
+    badge.hidden = true;
+    head.appendChild(badge);
+
+    shell.appendChild(head);
+
+    const valueRow = document.createElement('div');
+    valueRow.className = 'stat-value-row';
+
+    const valueEl = document.createElement('span');
+    valueEl.className = 'v';
+    valueRow.appendChild(valueEl);
+
+    const delta = document.createElement('span');
+    delta.className = 'delta';
+    delta.hidden = true;
+    valueRow.appendChild(delta);
+
+    shell.appendChild(valueRow);
+
+    const foot = document.createElement('div');
+    foot.className = 'stat-foot';
+
+    const progressWrap = document.createElement('div');
+    progressWrap.className = 'stat-progress';
+    progressWrap.hidden = true;
+
+    const progressTrack = document.createElement('div');
+    progressTrack.className = 'stat-progress-track';
+    const progressBar = document.createElement('div');
+    progressBar.className = 'stat-progress-bar';
+    progressTrack.appendChild(progressBar);
+
+    const progressValue = document.createElement('span');
+    progressValue.className = 'stat-progress-value';
+
+    progressWrap.append(progressTrack, progressValue);
+    foot.appendChild(progressWrap);
+
+    const sparkline = document.createElementNS('http://www.w3.org/2000/svg','svg');
+    sparkline.setAttribute('class','stat-sparkline');
+    sparkline.setAttribute('viewBox','0 0 120 36');
+    sparkline.setAttribute('preserveAspectRatio','none');
+    sparkline.hidden = true;
+
+    const sparkArea = document.createElementNS('http://www.w3.org/2000/svg','path');
+    const sparkLine = document.createElementNS('http://www.w3.org/2000/svg','polyline');
+    sparkline.append(sparkArea, sparkLine);
+
+    foot.appendChild(sparkline);
+    shell.appendChild(foot);
+
+    card.appendChild(shell);
+
+    if(preserved.length){
+      const extra = document.createElement('div');
+      extra.className = 'stat-extra';
+      preserved.forEach(node => extra.appendChild(node));
+      card.appendChild(extra);
+    }
+
+    card.classList.add('stat-card--hydrated');
+
+    const bundle = {shell, keyEl, badge, valueEl, delta, progressWrap, progressBar, progressValue, sparkline, sparkLine, sparkArea};
+    cardStore.set(card, bundle);
+    return bundle;
+  };
+
+  const ensureCard = (card) => cardStore.get(card) || buildCard(card);
+
+  const pickStatusClass = (status) => {
+    if(!status) return '';
+    const normalized = status.toLowerCase().trim();
+    return STATUS_CLASS_MAP[normalized] || STATUS_CLASS_MAP.default;
+  };
+
+  const parseSeries = (raw) => {
+    if(!raw) return [];
+    const trimmed = raw.trim();
+    if(!trimmed) return [];
+    if(trimmed.startsWith('[')){
+      try{
+        const arr = JSON.parse(trimmed);
+        if(Array.isArray(arr)){
+          return arr.map(Number).filter(Number.isFinite);
+        }
+      }catch(err){/* noop */}
+    }
+    return trimmed.split(/[\s,;|]+/).map(part => {
+      const value = parseFloat(part.replace(/_/g,''));
+      return Number.isFinite(value) ? value : NaN;
+    }).filter(Number.isFinite);
+  };
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  const renderSparkline = (values, nodes) => {
+    if(values.length === 0){
+      nodes.sparkline.hidden = true;
+      return;
+    }
+    const points = values.length === 1 ? [values[0], values[0]] : values.slice();
+    const width = 120;
+    const height = 36;
+    const padding = 4;
+    const maxVal = Math.max(...points);
+    const minVal = Math.min(...points);
+    const range = maxVal - minVal || 1;
+    const step = (width - padding * 2) / (points.length - 1 || 1);
+    const graphHeight = height - padding * 2;
+    const coords = points.map((value, index) => {
+      const ratio = (value - minVal) / range;
+      const x = padding + step * index;
+      const y = height - padding - ratio * graphHeight;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    });
+
+    nodes.sparkline.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    nodes.sparkLine.setAttribute('points', coords.join(' '));
+
+    const lastX = padding + step * (points.length - 1);
+    const areaPath = `M${padding} ${height - padding} ` + coords.map(point => `L ${point}`).join(' ') + ` L ${lastX.toFixed(2)} ${height - padding} Z`;
+    nodes.sparkArea.setAttribute('d', areaPath);
+    nodes.sparkline.hidden = false;
+  };
+
+  const updateCard = (card) => {
+    if(!hasRelevantData(card)) return;
+    const nodes = ensureCard(card);
+    const dataset = card.dataset;
+
+    nodes.keyEl.textContent = dataset.key || '';
+
+    const value = dataset.value;
+    nodes.valueEl.textContent = value !== undefined ? value : '';
+
+    const badgeClass = pickStatusClass(dataset.status || '');
+    nodes.badge.classList.remove(...BADGE_VARIANTS);
+    if(dataset.status && dataset.status.trim()){
+      nodes.badge.hidden = false;
+      if(badgeClass){
+        nodes.badge.classList.add(badgeClass);
+      }
+      nodes.badge.textContent = dataset.status;
+    }else{
+      nodes.badge.hidden = true;
+      nodes.badge.textContent = '';
+    }
+
+    const deltaRaw = dataset.delta;
+    nodes.delta.classList.remove(...DELTA_VARIANTS);
+    if(deltaRaw && deltaRaw.trim()){
+      const trimmed = deltaRaw.trim();
+      const numeric = parseFloat(trimmed.replace(/,/g,'.'));
+      let deltaClass = 'delta-neutral';
+      let arrow = '';
+      if(Number.isFinite(numeric)){
+        if(numeric > 0){
+          arrow = '▲';
+          deltaClass = 'delta-positive';
+        }else if(numeric < 0){
+          arrow = '▼';
+          deltaClass = 'delta-negative';
+        }else{
+          arrow = '—';
+          deltaClass = 'delta-neutral';
+        }
+      }
+      const magnitude = Number.isFinite(numeric) && /^[+\-]/.test(trimmed)
+        ? trimmed.slice(1).trim() || Math.abs(numeric).toString()
+        : trimmed;
+      nodes.delta.textContent = arrow ? `${arrow} ${magnitude}`.trim() : magnitude;
+      nodes.delta.classList.add(deltaClass);
+      nodes.delta.hidden = false;
+    }else{
+      nodes.delta.hidden = true;
+      nodes.delta.textContent = '';
+    }
+
+    const progressRaw = dataset.progress;
+    if(progressRaw !== undefined && progressRaw !== ''){
+      const numeric = parseFloat(String(progressRaw).replace(/,/g,'.'));
+      if(Number.isFinite(numeric)){
+        const valueClamped = clamp(numeric, 0, 100);
+        nodes.progressBar.style.width = `${valueClamped}%`;
+        const rounded = Math.round(valueClamped * 10) / 10;
+        const formatted = Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+        nodes.progressValue.textContent = formatted;
+        nodes.progressWrap.hidden = false;
+      }else{
+        nodes.progressWrap.hidden = true;
+        nodes.progressBar.style.width = '0%';
+        nodes.progressValue.textContent = '';
+      }
+    }else{
+      nodes.progressWrap.hidden = true;
+      nodes.progressBar.style.width = '0%';
+      nodes.progressValue.textContent = '';
+    }
+
+    const seriesValues = parseSeries(dataset.series);
+    if(seriesValues.length){
+      renderSparkline(seriesValues, nodes);
+    }else{
+      nodes.sparkline.hidden = true;
+    }
+  };
+
+  const hydrate = (root) => {
+    const scope = root instanceof Element ? root : document;
+    scope.querySelectorAll(SELECTOR).forEach(updateCard);
+    if(scope instanceof Element && scope.matches && scope.matches(SELECTOR)){
+      updateCard(scope);
+    }
+  };
+
+  const onReady = () => hydrate(document);
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', onReady, {once:true});
+  }else{
+    onReady();
+  }
+
+  document.addEventListener('htmx:afterSwap', (event) => {
+    const target = event.detail && event.detail.target ? event.detail.target : document;
+    hydrate(target);
+  });
+
+  document.addEventListener('htmx:load', (event) => {
+    hydrate(event.target || document);
+  });
+
+  const observerConfig = {
+    subtree:true,
+    childList:true,
+    attributes:true,
+    attributeFilter:['data-key','data-value','data-delta','data-status','data-progress','data-series']
+  };
+
+  const startObserver = () => {
+    const body = document.body;
+    if(!body) return;
+    const observer = new MutationObserver((mutations) => {
+      for(const mutation of mutations){
+        if(mutation.type === 'attributes'){
+          const target = mutation.target;
+          if(target instanceof Element && target.matches(SELECTOR)){
+            updateCard(target);
+          }
+        }
+        if(mutation.type === 'childList'){
+          mutation.addedNodes.forEach(node => {
+            if(!(node instanceof Element)) return;
+            if(node.matches && node.matches(SELECTOR)){
+              updateCard(node);
+            }else{
+              hydrate(node);
+            }
+          });
+        }
+      }
+    });
+    observer.observe(body, observerConfig);
+  };
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', startObserver, {once:true});
+  }else{
+    startObserver();
+  }
+})();


### PR DESCRIPTION
## Summary
- add opt-in stat grid/card styles for responsive metric presentation
- hydrate stat-card nodes from data attributes to render values, deltas, status badges, progress bars, and sparklines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decd99239c8321bdeda34fd3759888