### PR TITLE
Ensure skip link is styled and accessible

### DIFF
--- a/mvp-tickets/static/ui.css
+++ b/mvp-tickets/static/ui.css
@@ -9,6 +9,23 @@
 html{font-size:clamp(14px,1.05vw,16px)}
 body{background-color:rgb(var(--bg));color:rgb(var(--fg));}
 
+.skip-link{
+  position:fixed;
+  top:1rem;
+  left:1rem;
+  padding:.5rem .75rem;
+  border-radius:.5rem;
+  border:1px solid rgba(148,163,184,.65);
+  background:#fff;
+  color:rgb(var(--fg));
+  font-weight:600;
+  transform:translateY(-200%);
+  transition:transform .2s ease, box-shadow .2s ease;
+  z-index:100;
+}
+.skip-link:focus{outline:3px solid rgba(59,130,246,.5);outline-offset:2px;transform:translateY(0);box-shadow:0 10px 30px rgba(15,23,42,.2);}
+.dark .skip-link{background:rgba(15,23,42,.95);border-color:rgba(148,163,184,.55);color:rgb(var(--fg));}
+
 .card{border:1px solid rgba(148,163,184,.25);border-radius:var(--radius);
   background:rgba(255,255,255,.75);backdrop-filter:saturate(140%) blur(6px);
   box-shadow:0 1px 2px rgba(0,0,0,.04)}

--- a/mvp-tickets/static/ui.js
+++ b/mvp-tickets/static/ui.js
@@ -256,18 +256,23 @@
   window.addEventListener('mousedown',()=>{ if(tabbed){ tabbed=false; document.body.classList.remove('user-tabbed'); } });
 
   // Skip link + landmark main sin tocar templates
-  (function injectSkipLink(){
+  (function ensureSkipLink(){
     const id='main-content';
     let main = document.querySelector('main,[role="main"]');
     if(!main){
       main=document.createElement('div'); main.id=id; main.setAttribute('role','main'); main.tabIndex=-1;
       document.body.insertBefore(main, document.body.firstChild);
     }else if(!main.id){ main.id=id; }
+
+    const existing = document.querySelector('.skip-link');
+    if(existing){
+      if(!existing.getAttribute('href')) existing.setAttribute('href','#'+main.id);
+      return;
+    }
+
     const skip=document.createElement('a');
     skip.href='#'+main.id; skip.textContent='Saltar al contenido';
-    skip.style.cssText='position:fixed;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;z-index:1000;background:#fff;padding:.5rem .75rem;border-radius:.5rem;border:1px solid #cbd5e1';
-    skip.addEventListener('focus',()=>{skip.style.left='1rem'; skip.style.top='1rem'; skip.style.width='auto'; skip.style.height='auto';});
-    skip.addEventListener('blur',()=>{skip.style.left='-999px'; skip.style.width='1px'; skip.style.height='1px';});
+    skip.className='skip-link';
     document.body.insertBefore(skip, document.body.firstChild);
   })();
 

--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -1,8 +1,9 @@
 {% load static %}
 {% load roles notifications %} {# filtros personalizados #}
 <!doctype html>
-<html lang="es">
+<html lang="es" data-theme="default">
 <head>
+  <!-- UI-REFRESH-SAFE v1 -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Helpdesk{% endblock %}</title>
@@ -82,6 +83,7 @@
   {% block head_extra %}{% endblock %}
 </head>
 <body class="bg-gray-50 text-gray-900">
+  <a class="skip-link" href="#main-content">Saltar al contenido</a>
   {% if messages %}
   <div class="toast-wrap" role="status" aria-live="polite">
     {% for message in messages %}
@@ -164,7 +166,7 @@
   </header>
 
 
-  <main class="w-full px-6 py-6">
+  <main id="main-content" class="w-full px-6 py-6" tabindex="-1">
     {% block content %}{% endblock %}
   </main>
 


### PR DESCRIPTION
## Summary
- add the UI refresh marker and default theme attribute to the base layout
- expose a persistent skip link target and tabindex for the main content region
- reuse the existing auto-upgrade skip link helper without duplicating markup and style it for light/dark themes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded45cede48321add661e3ac5a00bf