### PR TITLE
Add STATICFILES_DIRS for project static assets

### DIFF
--- a/mvp-tickets/helpdesk/settings.py
+++ b/mvp-tickets/helpdesk/settings.py
@@ -97,6 +97,7 @@ USE_TZ = True
 # Static/Media (dev)
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_DIRS = [BASE_DIR / "static"]
 MEDIA_URL = "media/"
 MEDIA_ROOT = BASE_DIR / "media"
 


### PR DESCRIPTION
## Summary
- configure Django to include the project-level static directory in staticfiles lookups

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dede6996f88321ae29e37a68bd4807