### PR TITLE
Fix inconsistent theme toggling between light and dark modes

### DIFF
--- a/mvp-tickets/static/ui.js
+++ b/mvp-tickets/static/ui.js
@@ -25,7 +25,12 @@
   }
 
   function currentPreference() {
-    const stored = localStorage.getItem("theme");
+    let stored;
+    try {
+      stored = localStorage.getItem("theme");
+    } catch (error) {
+      stored = undefined;
+    }
     if (stored === "dark" || stored === "light") {
       return stored;
     }
@@ -35,7 +40,13 @@
   apply(currentPreference());
 
   media.addEventListener("change", (event) => {
-    if (!localStorage.getItem("theme")) {
+    let stored;
+    try {
+      stored = localStorage.getItem("theme");
+    } catch (error) {
+      stored = undefined;
+    }
+    if (!stored) {
       apply(event.matches ? "dark" : "light");
     }
   });
@@ -43,7 +54,11 @@
   if (toggle) {
     toggle.addEventListener("click", () => {
       const next = root.classList.contains("dark") ? "light" : "dark";
-      localStorage.setItem("theme", next);
+      try {
+        localStorage.setItem("theme", next);
+      } catch (error) {
+        // noop
+      }
       apply(next);
     });
   }

--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -19,6 +19,24 @@
   <!-- Bootstrap Icons -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
 
+  <script>
+    (function () {
+      const root = document.documentElement;
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      let theme;
+      try {
+        const stored = localStorage.getItem("theme");
+        theme = stored === "dark" || stored === "light" ? stored : undefined;
+      } catch (error) {
+        theme = undefined;
+      }
+      if (!theme) {
+        theme = media.matches ? "dark" : "light";
+      }
+      root.classList.toggle("dark", theme === "dark");
+      root.setAttribute("data-theme", theme);
+    })();
+  </script>
   <link rel="stylesheet" href="{% static 'css/theme.css' %}">
   <link rel="stylesheet" href="{% static 'ui.css' %}">
   {% block head_extra %}{% endblock %}
@@ -131,18 +149,6 @@
   </div>
 
   {% block body_extra %}{% endblock %}
-  <script>
-    (function(){
-      var saved=localStorage.getItem("theme");
-      if(saved) document.documentElement.setAttribute("data-theme",saved);
-      document.getElementById("theme-toggle")?.addEventListener("click",function(){
-        var cur=document.documentElement.getAttribute("data-theme")||"light";
-        var next=cur==="dark"?"light":"dark";
-        document.documentElement.setAttribute("data-theme",next);
-        localStorage.setItem("theme",next);
-      });
-    })();
-  </script>
   <script src="{% static 'ui.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- initialize the document theme before styles load so the correct palette applies immediately
- rely on the shared UI script for toggling while hardening it against unavailable localStorage

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68dee7d29250832182624b5dc4f9d2e0