### PR TITLE
Improve dashboard hero contrast in light theme

### DIFF
--- a/mvp-tickets/static/ui.css
+++ b/mvp-tickets/static/ui.css
@@ -568,6 +568,89 @@ a:focus-visible {
   gap: 1rem;
 }
 
+.hero-panel {
+  color: rgb(var(--text));
+}
+
+.hero-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--accent-strong), 0.85);
+}
+
+html[data-theme="dark"] .hero-eyebrow {
+  color: rgba(var(--accent-soft), 0.9);
+}
+
+.hero-eyebrow__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: rgba(var(--accent-strong), 0.9);
+  box-shadow: 0 0 0 2px rgba(var(--accent-strong), 0.2);
+}
+
+html[data-theme="dark"] .hero-eyebrow__dot {
+  background: rgba(var(--accent-soft), 0.85);
+  box-shadow: 0 0 0 2px rgba(var(--accent-soft), 0.25);
+}
+
+.hero-title {
+  font-size: clamp(2.25rem, 3.3vw, 2.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: rgb(var(--text));
+}
+
+.hero-subtitle {
+  font-size: 1rem;
+  color: rgba(var(--text-soft), 0.9);
+}
+
+html[data-theme="dark"] .hero-subtitle {
+  color: rgba(var(--text-soft), 0.85);
+}
+
+.hero-metric__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(var(--text-muted), 0.8);
+}
+
+.hero-metric__value {
+  font-size: clamp(2.8rem, 5vw, 3.4rem);
+  font-weight: 700;
+  color: rgb(var(--text));
+}
+
+html[data-theme="dark"] .hero-metric__value {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.hero-metric__description {
+  font-size: 0.9rem;
+  color: rgba(var(--text-soft), 0.8);
+}
+
+.hero-metric__meta {
+  color: rgba(var(--text-muted), 0.85);
+}
+
+html[data-theme="dark"] .hero-metric__meta {
+  color: rgba(var(--text-muted), 0.8);
+}
+
+.hero-metric__status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: rgba(var(--success), 0.85);
+  box-shadow: 0 0 0 2px rgba(var(--success), 0.25);
+}
+
 .stat-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/mvp-tickets/templates/dashboard.html
+++ b/mvp-tickets/templates/dashboard.html
@@ -5,16 +5,16 @@
 {% block content %}
 <section class="space-y-10">
   <header class="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
-    <article class="surface-panel surface-panel--gradient overflow-hidden">
+    <article class="surface-panel surface-panel--gradient overflow-hidden hero-panel">
       <div class="flex flex-col justify-between gap-8 lg:flex-row">
         <div class="max-w-xl space-y-5">
-          <div class="flex items-center gap-3 text-sm uppercase tracking-[0.2em] text-sky-200">
-            <span class="inline-flex h-2 w-2 rounded-full bg-sky-200"></span>
+          <div class="flex items-center gap-3 hero-eyebrow">
+            <span class="hero-eyebrow__dot"></span>
             Panel ejecutivo
           </div>
           <div class="space-y-3">
-            <h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">Tu mesa de ayuda, en modo misión crítica</h1>
-            <p class="text-base text-sky-100/80">Observa el ritmo operativo, desbloquea cuellos de botella y alinea a tu equipo con decisiones respaldadas por datos en segundos.</p>
+            <h1 class="hero-title">Tu mesa de ayuda, en modo misión crítica</h1>
+            <p class="hero-subtitle">Observa el ritmo operativo, desbloquea cuellos de botella y alinea a tu equipo con decisiones respaldadas por datos en segundos.</p>
           </div>
           <div class="flex flex-wrap gap-3">
             <a href="{% url 'tickets_home' %}" class="btn btn-primary"><i class="bi bi-life-preserver"></i> Ver tablero de tickets</a>
@@ -23,11 +23,11 @@
         </div>
         <div class="grid h-full w-full max-w-xs place-content-center rounded-3xl bg-white/15 px-6 py-8 text-center shadow-lg shadow-sky-900/20 backdrop-blur">
           <div class="space-y-4">
-            <p class="text-xs uppercase tracking-[0.25em] text-sky-50/70">Pulso actual</p>
-            <p class="text-5xl font-semibold text-white">{{ counts.open|default:0 }}</p>
-            <p class="text-sm text-sky-100/80">Tickets activos exigiendo respuesta inmediata.</p>
-            <div class="flex items-center justify-center gap-2 text-xs font-medium text-sky-50/70">
-              <span class="inline-flex h-2 w-2 rounded-full bg-emerald-300"></span>
+            <p class="hero-metric__label">Pulso actual</p>
+            <p class="hero-metric__value">{{ counts.open|default:0 }}</p>
+            <p class="hero-metric__description">Tickets activos exigiendo respuesta inmediata.</p>
+            <div class="flex items-center justify-center gap-2 text-xs font-medium hero-metric__meta">
+              <span class="hero-metric__status-dot"></span>
               Ritmo saludable
             </div>
           </div>


### PR DESCRIPTION
## Summary
- introduce semantic hero typography styles that leverage the design tokens for each theme
- update the dashboard hero markup to rely on the new classes instead of hardcoded light-on-dark colors

## Testing
- Not run (Django dependencies unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dee98f676c8321bba0255da33cfd28